### PR TITLE
Freeze python package versions to prevent dependency/compatibility issues

### DIFF
--- a/R/setup_gpu_modules.R
+++ b/R/setup_gpu_modules.R
@@ -15,8 +15,10 @@ setup_gpu_modules <- function()
 
   # Set necessary modules
   modules <- c(
-    "autoawq", "auto-gptq", "optimum"
+    "autoawq==0.2.5", "auto-gptq==0.7.1", "optimum==1.19.1"
   )
+
+# TODO freeze versions of modules to their current versions
 
   # Check for Linux
   if(system.check()$OS == "linux"){

--- a/R/setup_modules.R
+++ b/R/setup_modules.R
@@ -16,7 +16,7 @@ setup_modules <- function()
   # Set necessary modules
   modules <- c(
     "accelerate==0.29.3", "llama-index==0.10.30", "nltk==3.8.1",
-    "opencv-python", "pandas==2.1.3", "pypdf==3.17.1",
+    "opencv-python", "pandas==2.1.3", "pypdf==4.0.1",
     "pytube==15.0.0", "pytz==2024.1", "qdrant-client==1.8.2",
     "sentencepiece==0.2.0", "tensorflow==2.14.1", "torch==2.1.1",
     # "torchaudio", "torchvision",

--- a/R/setup_modules.R
+++ b/R/setup_modules.R
@@ -19,7 +19,6 @@ setup_modules <- function()
     "opencv-python", "pandas==2.1.3", "pypdf==4.0.1",
     "pytube==15.0.0", "pytz==2024.1", "qdrant-client==1.8.2",
     "sentencepiece==0.2.0", "tensorflow==2.14.1", "torch==2.1.1",
-    # "torchaudio", "torchvision",
     "transformers==4.35.0"
   )
 

--- a/R/setup_modules.R
+++ b/R/setup_modules.R
@@ -15,11 +15,12 @@ setup_modules <- function()
 
   # Set necessary modules
   modules <- c(
-    "accelerate", "llama-index", "nltk",
-    "opencv-python", "pandas", "pypdf",
-    "pytube", "pytz", "qdrant-client",
-    "sentencepiece", "tensorflow", "torch",
-    "torchaudio", "torchvision", "transformers"
+    "accelerate==0.29.3", "llama-index==0.10.30", "nltk==3.8.1",
+    "opencv-python", "pandas==2.1.3", "pypdf==3.17.1",
+    "pytube==15.0.0", "pytz==2024.1", "qdrant-client==1.8.2",
+    "sentencepiece==0.2.0", "tensorflow==2.14.1", "torch==2.1.1",
+    # "torchaudio", "torchvision",
+    "transformers==4.35.0"
   )
 
   # Determine whether any modules need to be installed

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Path can be either local or an URL. Here's an example of using a URL of Mona Lis
 ```R
 
 # Image URL or local filepath
-image <- "https://upload.wikimedia.org/wikipedia/commons/thumb/7/76/Leonardo_da_Vinci_-_Mona_Lisa.jpg/401px-Leonardo_da_Vinci_-_Mona_Lisa.jpg"
+image <- 'https://cdn.mos.cms.futurecdn.net/xRqbwS4odpkSQscn3jHECh-650-80.jpg'
 
 # Array of emotion labels
 emotions <- c("excitement", "happiness", "pride", "anger", "fear", "sadness", "neutral")

--- a/inst/python/image.py
+++ b/inst/python/image.py
@@ -84,7 +84,7 @@ def get_text_embeds(labels):
     processor_openai
     model_openai
   except NameError:
-    print("Loading OpenAI CLIP model ... \n This may take a minute.")
+    print("Loading OpenAI CLIP model ...")
     processor_openai = AutoProcessor.from_pretrained("openai/clip-vit-base-patch32")
     model_openai = AutoModel.from_pretrained("openai/clip-vit-base-patch32")
   text_inputs_openai = processor_openai(text=labels, return_tensors='pt', padding=True)

--- a/inst/python/video.py
+++ b/inst/python/video.py
@@ -6,12 +6,12 @@ import numpy as np
 import pandas as pd
 from pytube import YouTube
 from transformers import AutoProcessor, AutoModel
-import torch
-from torch import nn
-import torchvision.models as models
-from torchvision import transforms
+# import torch
+# from torch import nn
+# import torchvision.models as models
+# from torchvision import transforms
 import torch.nn.functional as F
-from PIL import Image
+# from PIL import Image
 import time
 
 

--- a/man/MASS_mvrnorm.Rd
+++ b/man/MASS_mvrnorm.Rd
@@ -4,14 +4,7 @@
 \alias{MASS_mvrnorm}
 \title{Multivariate Normal (Gaussian) Distribution}
 \usage{
-MASS_mvrnorm(
-  n = 1,
-  mu,
-  Sigma,
-  tol = 0.000001,
-  empirical = FALSE,
-  EISPACK = FALSE
-)
+MASS_mvrnorm(n = 1, mu, Sigma, tol = 1e-06, empirical = FALSE, EISPACK = FALSE)
 }
 \arguments{
 \item{n}{Numeric integer.


### PR DESCRIPTION
This PR introduces fixed package versions.

### Standard libraries

```R
  modules <- c(
    "accelerate==0.29.3", "llama-index==0.10.30", "nltk==3.8.1",
    "opencv-python", "pandas==2.1.3", "pypdf==4.0.1",
    "pytube==15.0.0", "pytz==2024.1", "qdrant-client==1.8.2",
    "sentencepiece==0.2.0", "tensorflow==2.14.1", "torch==2.1.1",
    "transformers==4.35.0"
  )
```

### GPU libriaries

```R
  modules <- c(
    "autoawq==0.2.5", "auto-gptq==0.7.1", "optimum==1.19.1"
  )
```