### PR TITLE
Video detection problems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ rsconnect/
 
 # Notes folder
 /notes/
+
+# Playground folder
+/playground/

--- a/R/setup_modules.R
+++ b/R/setup_modules.R
@@ -16,10 +16,10 @@ setup_modules <- function()
   # Set necessary modules
   modules <- c(
     "accelerate==0.29.3", "llama-index==0.10.30", "nltk==3.8.1",
-    "opencv-python", "pandas==2.1.3", "pypdf==4.0.1",
-    "pytube==15.0.0", "pytz==2024.1", "qdrant-client==1.8.2",
+    "opencv-python", "pandas==2.1.3", "pypdf==4.0.1", "pytz==2024.1", "qdrant-client==1.8.2",
     "sentencepiece==0.2.0", "sentence-transformers==2.7.0",
-    "tensorflow==2.14.1", "torch==2.1.1", "transformers==4.35.0"
+    "tensorflow==2.14.1", "torch==2.1.1", "transformers==4.35.0",
+    "pytubefix==6.9.2"
   )
 
   # Determine whether any modules need to be installed

--- a/inst/python/video.py
+++ b/inst/python/video.py
@@ -4,14 +4,9 @@ import math
 import cv2 
 import numpy as np
 import pandas as pd
-from pytube import YouTube
+from pytubefix import YouTube #19 Fixed pytube issue
 from transformers import AutoProcessor, AutoModel
-# import torch
-# from torch import nn
-# import torchvision.models as models
-# from torchvision import transforms
 import torch.nn.functional as F
-# from PIL import Image
 import time
 
 


### PR DESCRIPTION
Fixes #19

`pytubefix` library is now used instead of `pytube`. See: https://pypi.org/project/pytubefix/

Frozen to pytubefix 6.9.2